### PR TITLE
fix: Add permissions section to CI/CD pipeline configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,14 @@
 name: CI/CD Pipeline
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:
       - main
     tags:
-      - "v*" # Run when version tags are pushed
+      - "v*"
 
 jobs:
   test:


### PR DESCRIPTION
This pull request updates the CI/CD pipeline configuration to adjust permissions and clean up formatting.

Changes to `.github/workflows/ci.yml`:

* Added `permissions` block with `contents: write` to specify repository access permissions for the workflow.
* Removed an unnecessary comment and adjusted formatting for the `tags` section.