### PR TITLE
fix: Update project version to 0.5.1 and change project config path to use current working directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "handmark"
-version = "0.5.0"
+version = "0.5.1"
 description = "Transform handwritten images into structured documents (Markdown, JSON, YAML, XML)"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -31,3 +31,6 @@ handmark = "main:main"
 dev = [
     "flake8>=7.3.0",
 ]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/config.py
+++ b/src/config.py
@@ -39,8 +39,7 @@ def get_config_path() -> Path:
 
 def get_project_config_path() -> Path:
     """Get the path to the project-wide configuration file"""
-    project_dir = Path(__file__).parent.parent
-    return project_dir / "config.yaml"
+    return Path.cwd() / "config.yaml"
 
 
 def load_project_config() -> dict:


### PR DESCRIPTION
This pull request updates the project configuration handling and improves package discovery for the `handmark` project. The most important changes include updating how the project-wide configuration file is located and ensuring that setuptools correctly finds packages in the `src` directory.

Configuration handling improvements:
* Changed `get_project_config_path()` in `src/config.py` to use the current working directory for locating `config.yaml`, making configuration loading more flexible and predictable.

Packaging and setup enhancements:
* Added `[tool.setuptools.packages.find]` section to `pyproject.toml` to specify that packages should be found in the `src` directory, improving compatibility with modern Python packaging standards.
* Bumped the project version from `0.5.0` to `0.5.1` in `pyproject.toml` to reflect these changes.