### PR TITLE
ci(mirror)/add mirror workflow to codeberg

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,22 @@
+name: Mirror to Codeberg
+
+on:
+  push:
+    branches: [main]
+    tags: ["*"]
+  workflow_dispatch:
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Mirror to Codeberg
+        uses: pixta-dev/repository-mirroring-action@v1
+        with:
+          target_repo_url: git@codeberg.org:devgabrielsborges/handmark.git
+          ssh_private_key: ${{ secrets.CODEBERG_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically mirror the repository to Codeberg whenever changes are pushed to the `main` branch or when tags are created.

**CI/CD Automation:**

* Added a new workflow file `.github/workflows/mirror.yml` that uses the `pixta-dev/repository-mirroring-action` to sync the repository to Codeberg on every push to `main` and on tag creation, using an SSH private key stored in repository secrets.